### PR TITLE
リリースPRを作成するワークフローの作成

### DIFF
--- a/.github/hotfix-pr-body.md
+++ b/.github/hotfix-pr-body.md
@@ -1,1 +1,0 @@
-# Hotfix Release PR

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,144 @@
+name: Create Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        type: choice
+        required: true
+        default: 'minor'
+        description: 'バージョンアップのタイプを選択してください'
+        options:
+          - 'minor'
+          - 'major'
+          - 'patch'
+      custom_version:
+        type: string
+        required: false
+        description: 'カスタムバージョンを指定する場合は入力してください (例: 1.2.3)'
+      build_number:
+        type: string
+        required: false
+        description: 'ビルド番号を指定してください。指定がなければ、最新のビルド番号に100を加えたものが使用されます'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: リポジトリをチェックアウト
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: 最新のリリースタグを取得
+        id: get-latest-tag
+        run: |
+          latest_tag=$(git describe --tags `git rev-list --tags --max-count=1` 2>/dev/null || echo "0.0.0-0")
+          echo "tag=$latest_tag" >> $GITHUB_OUTPUT
+
+      - name: 現在のバージョンを取得
+        id: get-current-version
+        run: |
+          current_version=$(grep -E '^version:' pubspec.yaml | sed -E 's/version:\s+//')
+          echo "version=$current_version" >> $GITHUB_OUTPUT
+          
+          # Extract build number
+          current_build_number=$(echo "$current_version" | sed -e 's/.*-//')
+          echo "current_build_number=$current_build_number" >> $GITHUB_OUTPUT
+
+      - name: Dartをセットアップする
+        uses: ./.github/actions/setup-dart
+
+      - name: バージョンをバンプする
+        id: bump-version
+        run: |
+          dart pub global activate cider
+          
+          # Calculate new build number
+          build_number="${{ github.event.inputs.build_number }}"
+          if [ -z "$build_number" ]; then
+            build_number=$(( ${{ steps.get-current-version.outputs.current_build_number }} + 100 ))
+            echo "ビルド番号が指定されていません。計算されたビルド番号を使用します: $build_number"
+          fi
+          
+          # Convert version format for cider (- to +)
+          sed -i -E 's/version: ([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)/version: \1+\2/' pubspec.yaml
+          
+          # Handle custom version if provided
+          if [ -n "${{ github.event.inputs.custom_version }}" ]; then
+            cider version "${{ github.event.inputs.custom_version }}+$build_number"
+          else
+            # Otherwise bump according to version_type
+            cider bump ${{ github.event.inputs.version_type }} --build=$build_number
+          fi
+          
+          # Convert version format back (+ to -)
+          sed -i -E 's/version: ([0-9]+\.[0-9]+\.[0-9]+)\+([0-9]+)/version: \1-\2/' pubspec.yaml
+          
+          # Get the new version
+          new_version=$(cider version)
+          version_without_build=$(echo "$new_version" | sed -e 's/-.*$//')
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT
+          echo "version_without_build=$version_without_build" >> $GITHUB_OUTPUT
+          echo "build_number=$build_number" >> $GITHUB_OUTPUT
+
+      - name: リリースブランチを作成
+        id: create-release-branch
+        run: |
+          branch_name="release-${{ steps.bump-version.outputs.version_without_build }}"
+          
+          # Check if branch already exists
+          existing_branch=$(git ls-remote --heads origin "$branch_name")
+          if [ -n "$existing_branch" ]; then
+            echo "$branch_name が存在していたので削除します。"
+            git push origin --delete "$branch_name"
+          fi
+          
+          echo "Creating branch: $branch_name"
+          git checkout -b "$branch_name"
+          git push --set-upstream origin "$branch_name"
+          echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
+
+      - name: Configure Git user
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add pubspec.yaml pubspec.lock
+          git status
+
+      - name: コミットとプッシュ
+        run: |
+          git commit -m "Bump version to ${{ steps.bump-version.outputs.new_version }}" || echo "No changes to commit"
+          git push --set-upstream origin ${{ steps.create-release-branch.outputs.branch_name }}
+
+      - name: リリースノートの内容を取得
+        id: get-release-notes
+        run: |
+          if [ -f "release-note-body.md" ]; then
+            echo "release_notes<<EOF" >> $GITHUB_OUTPUT
+            cat release-note-body.md >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          else
+            echo "release_notes=## What's Changed" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Create PR body with release notes
+          echo "# Release ${{ steps.bump-version.outputs.version_without_build }}" > pr_body.md
+          echo "" >> pr_body.md
+          echo "${{ steps.get-release-notes.outputs.release_notes }}" >> pr_body.md
+          
+          gh pr create \
+            --base main \
+            --head ${{ steps.create-release-branch.outputs.branch_name }} \
+            --label "release" \
+            --title "Release ${{ steps.bump-version.outputs.version_without_build }}" \
+            --body-file pr_body.md

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           current_version=$(grep -E '^version:' pubspec.yaml | sed -E 's/version:\s+//')
           echo "version=$current_version" >> $GITHUB_OUTPUT
-          
+
           # Extract build number
           current_build_number=$(echo "$current_version" | sed -e 's/.*-//')
           echo "current_build_number=$current_build_number" >> $GITHUB_OUTPUT
@@ -58,14 +58,14 @@ jobs:
         id: bump-version
         run: |
           dart pub global activate cider
-          
+
           # Calculate new build number
           build_number="${{ github.event.inputs.build_number }}"
           if [ -z "$build_number" ]; then
             build_number=$(( ${{ steps.get-current-version.outputs.current_build_number }} + 100 ))
             echo "ビルド番号が指定されていません。計算されたビルド番号を使用します: $build_number"
           fi
-          
+
           # Convert version format for cider (- to +)
           sed -i -E 's/version: ([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)/version: \1+\2/' pubspec.yaml
           # Handle custom version if provided
@@ -75,7 +75,7 @@ jobs:
             # Otherwise bump according to version_type
             cider bump ${{ github.event.inputs.version_type }} --build=$build_number
           fi
-          
+
           # Convert version format back (+ to -)
           sed -i -E 's/version: ([0-9]+\.[0-9]+\.[0-9]+)\+([0-9]+)/version: \1-\2/' pubspec.yaml
           # Get the new version
@@ -89,7 +89,7 @@ jobs:
         id: create-release-branch
         run: |
           branch_name="release-${{ steps.bump-version.outputs.version_without_build }}"
-          
+
           # Check if branch already exists
           existing_branch=$(git ls-remote --heads origin "$branch_name")
           if [ -n "$existing_branch" ]; then
@@ -105,7 +105,7 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add pubspec.yaml pubspec.lock
+          git add pubspec.yaml
           git status
 
       - name: コミットとプッシュ

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -68,7 +68,6 @@ jobs:
           
           # Convert version format for cider (- to +)
           sed -i -E 's/version: ([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)/version: \1+\2/' pubspec.yaml
-          
           # Handle custom version if provided
           if [ -n "${{ github.event.inputs.custom_version }}" ]; then
             cider version "${{ github.event.inputs.custom_version }}+$build_number"
@@ -79,7 +78,6 @@ jobs:
           
           # Convert version format back (+ to -)
           sed -i -E 's/version: ([0-9]+\.[0-9]+\.[0-9]+)\+([0-9]+)/version: \1-\2/' pubspec.yaml
-          
           # Get the new version
           new_version=$(cider version)
           version_without_build=$(echo "$new_version" | sed -e 's/-.*$//')
@@ -98,7 +96,6 @@ jobs:
             echo "$branch_name が存在していたので削除します。"
             git push origin --delete "$branch_name"
           fi
-          
           echo "Creating branch: $branch_name"
           git checkout -b "$branch_name"
           git push --set-upstream origin "$branch_name"
@@ -115,30 +112,13 @@ jobs:
         run: |
           git commit -m "Bump version to ${{ steps.bump-version.outputs.new_version }}" || echo "No changes to commit"
           git push --set-upstream origin ${{ steps.create-release-branch.outputs.branch_name }}
-
-      - name: リリースノートの内容を取得
-        id: get-release-notes
-        run: |
-          if [ -f "release-note-body.md" ]; then
-            echo "release_notes<<EOF" >> $GITHUB_OUTPUT
-            cat release-note-body.md >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-          else
-            echo "release_notes=## What's Changed" >> $GITHUB_OUTPUT
-          fi
-
       - name: Create PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Create PR body with release notes
-          echo "# Release ${{ steps.bump-version.outputs.version_without_build }}" > pr_body.md
-          echo "" >> pr_body.md
-          echo "${{ steps.get-release-notes.outputs.release_notes }}" >> pr_body.md
-          
           gh pr create \
             --base main \
             --head ${{ steps.create-release-branch.outputs.branch_name }} \
             --label "release" \
             --title "Release ${{ steps.bump-version.outputs.version_without_build }}" \
-            --body-file pr_body.md
+            --body-file "./pr-body/release-pr-body.md"

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add pubspec.yaml pubspec.lock
+          git add pubspec.yaml
           git status
 
       - name: コミットとプッシュ

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -102,4 +102,4 @@ jobs:
             --head ${{ steps.create-hotfix.outputs.branch_name }} \
             --label "A-build" \
             --title "release: Hotfix ${{ steps.bump-version.outputs.pubspec_version}}" \
-            --body-file "./.github/hotfix-pr-body.md"
+            --body-file "./pr-body/hotfix-pr-body.md"

--- a/pr-body/hotfix-pr-body.md
+++ b/pr-body/hotfix-pr-body.md
@@ -1,0 +1,1 @@
+# Hotfix Release PR Body

--- a/pr-body/release-pr-body.md
+++ b/pr-body/release-pr-body.md
@@ -1,0 +1,1 @@
+## Release PR Body

--- a/release-note-body.md
+++ b/release-note-body.md
@@ -1,2 +1,0 @@
-## What's Changed
-release body


### PR DESCRIPTION
Issue #42 の対応として、リリースPRを作成するワークフローを実装しました。

## 実装内容

- workflow_dispatch を使ってリリースPRを作成するワークフロー
- release-note-body.md の内容をPR bodyに追記
- main ブランチからPRを作成
- バージョニング
  - pubspec.yaml の cider を使ってバージョンを取得
  - ブランチ名は `release-x.x.x` (x.x.xはアップデートするバージョン名)
  - デフォルトでは最新のタグから minor バージョンをアップデート
  - major バージョンのアップデートもカスタマイズ可能
  - ビルド番号は100インクリメント (x.x.x-$(BUILD_NUMBER)の形式)

最新の hotfix.yml の修正内容も反映しています。