### PR TITLE
Fix: Delete existing release before creating a new one

### DIFF
--- a/.github/workflows/create-release-note.yml
+++ b/.github/workflows/create-release-note.yml
@@ -48,6 +48,36 @@ jobs:
           echo "latest_tag=$latest_tag" >> $GITHUB_OUTPUT
           echo "previous_tag=$previous_tag" >> $GITHUB_OUTPUT
 
+      - name: 既存のリリースを削除
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const tag = '${{ steps.get-tags.outputs.latest_tag }}';
+            try {
+              // リリースIDを取得
+              const releaseResponse = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: tag
+              });
+              
+              // リリースが存在する場合は削除
+              if (releaseResponse && releaseResponse.data) {
+                console.log(`既存のリリース (ID: ${releaseResponse.data.id}) を削除します`);
+                await github.rest.repos.deleteRelease({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  release_id: releaseResponse.data.id
+                });
+                console.log('既存のリリースを削除しました');
+              }
+            } catch (error) {
+              // リリースが見つからない場合はエラーを無視
+              console.log('既存のリリースが見つからないか、削除中にエラーが発生しました:', error.message);
+              console.log('新しいリリースを作成します');
+            }
+
       - name: リリースノートの作成
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
         with:


### PR DESCRIPTION
このPRは、リリースノート作成ワークフローを修正し、既存のリリースが存在する場合は削除してから新しいリリースを作成するようにします。

## 変更内容
- GitHub Actions workflowに新しいステップを追加して、既存のリリースを削除
- エラー処理を追加して、リリースが存在しない場合でも処理を継続

## 修正されるエラー
`Error 422: Validation Failed: {"resource":"Release","code":"already_exists","field":"tag_name"}`

この修正により、同じタグ名で新しいリリースノートを作成する際のエラーが解消されます。