### PR TITLE
feat: GitHub Actionsワークフローに明示的なpermissionsを追加

### DIFF
--- a/.github/workflows/cache-debug.yml
+++ b/.github/workflows/cache-debug.yml
@@ -23,6 +23,9 @@ on:
           - pubspec.yaml
           - .tool-versions
 
+permissions:
+  contents: read
+
 jobs:
   # ジョブ1: 基本的なキャッシュのデモンストレーション
   basic-cache-demo:

--- a/.github/workflows/check-date.yml
+++ b/.github/workflows/check-date.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-date:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     tags: ["*"]
     branches: ["main"]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/commit-to-branch.yml
+++ b/.github/workflows/commit-to-branch.yml
@@ -12,6 +12,9 @@ on:
         required: true
         default: 'Automated commit via GitHub Actions'
 
+permissions:
+  contents: write
+
 jobs:
   commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-release-note.yml
+++ b/.github/workflows/create-release-note.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [labeled]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   remove-label:
     if: github.event.label.name == 'create-release-note'

--- a/.github/workflows/demo-env.yml
+++ b/.github/workflows/demo-env.yml
@@ -1,5 +1,9 @@
 name: Environment Variables Demo
 on: push
+
+permissions:
+  contents: read
+
 env:
   GLOBAL_VAR: "Hello from workflow"        # ワークフロー全体の環境変数
 jobs:

--- a/.github/workflows/demo-matrix.yml
+++ b/.github/workflows/demo-matrix.yml
@@ -1,5 +1,9 @@
 name: Matrix Build Demo
 on: push
+
+permissions:
+  contents: read
+
 jobs:
   animal_matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/demo-multi-job.yml
+++ b/.github/workflows/demo-multi-job.yml
@@ -1,5 +1,9 @@
 name: Multi-Job Demo
 on: push
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/demo-secrets-vars.yml
+++ b/.github/workflows/demo-secrets-vars.yml
@@ -1,5 +1,9 @@
 name: Secrets and Vars Demo
 on: push
+
+permissions:
+  contents: read
+
 jobs:
   secrets_demo:
     runs-on: ubuntu-latest

--- a/.github/workflows/demo-trigger-main.yml
+++ b/.github/workflows/demo-trigger-main.yml
@@ -4,6 +4,10 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+
+permissions:
+  contents: read
+
 jobs:
   print-event:
     runs-on: ubuntu-latest

--- a/.github/workflows/download-artifact.yml
+++ b/.github/workflows/download-artifact.yml
@@ -3,6 +3,9 @@ name: Download artifact
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   get-results:
     runs-on: ubuntu-latest

--- a/.github/workflows/flutter-mise.yml
+++ b/.github/workflows/flutter-mise.yml
@@ -1,9 +1,11 @@
-
 name: Flutter CI with mise
 
 on:
   push:
     branches: [ main ]
+
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/generate-token.yml
+++ b/.github/workflows/generate-token.yml
@@ -2,6 +2,9 @@ name: Generate Token
 
 on: [workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   generate-token:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-from-server.yml
+++ b/.github/workflows/sync-from-server.yml
@@ -4,6 +4,10 @@ on:
   repository_dispatch:
     types: [server-release-updated]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   sync-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/ternary-operator-test.yml
+++ b/.github/workflows/ternary-operator-test.yml
@@ -12,6 +12,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   test-ternary-operator:
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger-label-action.yml
+++ b/.github/workflows/trigger-label-action.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [labeled]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   label-triggered-action:
     if: github.event.label.name == 'label-action'


### PR DESCRIPTION
セキュリティ向上のため、すべてのワークフローに明示的な
permissions設定を追加。最小権限の原則に従い、各ワークフローに
必要な権限のみを明示的に設定。

Closes #75

### What does this change?
